### PR TITLE
Expand gitignore files and update scala version

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,8 +1,10 @@
 target/
 .settings/
+.idea/
 
 .directory
 .tern-project
 .cache-main
 .project
 .classpath
+lending-parent.iml

--- a/lending-client/.gitignore
+++ b/lending-client/.gitignore
@@ -1,5 +1,6 @@
-/target/
-/.settings/
+target/
+.settings/
 
-/.project
-/.classpath
+.project
+.classpath
+lending-client.iml

--- a/lending-client/pom.xml
+++ b/lending-client/pom.xml
@@ -38,18 +38,18 @@
 		</dependency>
 		<dependency>
 			<groupId>com.github.pathikrit</groupId>
-			<artifactId>better-files_2.11</artifactId>
-			<version>2.13.0</version>
+			<artifactId>better-files_2.12</artifactId>
+			<version>3.0.0</version>
 		</dependency>
 		<dependency>
 			<groupId>org.scala-lang.modules</groupId>
-			<artifactId>scala-xml_2.11</artifactId>
-			<version>1.0.5</version>
+			<artifactId>scala-xml_2.12</artifactId>
+			<version>1.0.6</version>
 		</dependency>
 		<dependency>
 			<groupId>com.github.scopt</groupId>
-			<artifactId>scopt_2.11</artifactId>
-			<version>3.3.0</version>
+			<artifactId>scopt_2.12</artifactId>
+			<version>3.6.0</version>
 		</dependency>
 		<dependency>
 			<groupId>org.glassfish.jersey.core</groupId>
@@ -67,8 +67,8 @@
 		</dependency>
 		<dependency>
 			<groupId>org.scalafx</groupId>
-			<artifactId>scalafx_2.11</artifactId>
-			<version>8.0.92-R10</version>
+			<artifactId>scalafx_2.12</artifactId>
+			<version>8.0.102-R11</version>
 		</dependency>
 		<dependency>
 			<groupId>info.armado.darmstadtspielt</groupId>

--- a/lending-database/.gitignore
+++ b/lending-database/.gitignore
@@ -1,5 +1,6 @@
-/target/
-/.settings/
+target/
+.settings/
 
-/.project
-/.classpath
+.project
+.classpath
+lending-database.iml

--- a/lending-ear/.gitignore
+++ b/lending-ear/.gitignore
@@ -3,4 +3,4 @@ target/
 
 .project
 .classpath
-lending-rest-interfaces.iml
+lending-ear.iml

--- a/lending-rest-server/.gitignore
+++ b/lending-rest-server/.gitignore
@@ -3,4 +3,4 @@ target/
 
 .project
 .classpath
-lending-rest-interfaces.iml
+lending-rest-server.iml

--- a/lending-rest-server/pom.xml
+++ b/lending-rest-server/pom.xml
@@ -67,8 +67,8 @@
 		</dependency>
 		<dependency>
 			<groupId>org.scalatest</groupId>
-			<artifactId>scalatest_2.11</artifactId>
-			<version>3.0.0</version>
+			<artifactId>scalatest_2.12</artifactId>
+			<version>3.0.3</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>

--- a/lending-rest-server/src/test/scala/info/armado/ausleihe/remote/WebDeployment.scala
+++ b/lending-rest-server/src/test/scala/info/armado/ausleihe/remote/WebDeployment.scala
@@ -19,14 +19,14 @@ trait WebDeployment {
       .addAsLibraries {
         Maven
           .resolver
-          .resolve("org.scala-lang:scala-library:2.11.8")
+          .resolve("org.scala-lang:scala-library:2.12.2")
           .withTransitivity
           .asFile: _*
       }
       .addAsLibraries {
         Maven
           .resolver
-          .resolve("org.scalatest:scalatest_2.11:3.0.0")
+          .resolve("org.scalatest:scalatest_2.12:3.0.3")
           .withTransitivity
           .asFile: _*
       }

--- a/lending-web-server/.gitignore
+++ b/lending-web-server/.gitignore
@@ -5,3 +5,4 @@
 
 /.project
 /.classpath
+lending-web-server.iml

--- a/pom.xml
+++ b/pom.xml
@@ -48,7 +48,7 @@
 			<dependency>
 				<groupId>org.scala-lang</groupId>
 				<artifactId>scala-library</artifactId>
-				<version>2.11.8</version>
+				<version>2.12.2</version>
 			</dependency>
 			<dependency>
 				<groupId>org.apache.poi</groupId>
@@ -103,12 +103,6 @@
 				<groupId>org.wildfly.plugins</groupId>
 				<artifactId>wildfly-maven-plugin</artifactId>
 				<version>1.0.2.Final</version>
-			</plugin>
-			<!-- Plugin to support delomboking -->
-			<plugin>
-				<groupId>org.projectlombok</groupId>
-				<artifactId>lombok-maven-plugin</artifactId>
-				<version>1.16.4.1</version>
 			</plugin>
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>


### PR DESCRIPTION
This PR expands the `.gitignore` files by adding IntelliJ specific files.
In addition, the `scala` version and all related libraries are updated from scala 2.11 to scala 2.12.