### PR TITLE
Update arquillian persistence extension

### DIFF
--- a/lending-rest-server/pom.xml
+++ b/lending-rest-server/pom.xml
@@ -14,21 +14,21 @@
 			<dependency>
 				<groupId>org.jboss.arquillian</groupId>
 				<artifactId>arquillian-bom</artifactId>
-				<version>1.1.11.Final</version>
+				<version>1.1.13.Final</version>
 				<scope>import</scope>
 				<type>pom</type>
 			</dependency>
 			<dependency>
 				<groupId>org.jboss.shrinkwrap.resolver</groupId>
 				<artifactId>shrinkwrap-resolver-bom</artifactId>
-				<version>2.2.4</version>
+				<version>2.2.6</version>
 				<type>pom</type>
 				<scope>import</scope>
 			</dependency>
 			<dependency>
 				<groupId>org.jboss.arquillian.extension</groupId>
 				<artifactId>arquillian-transaction-bom</artifactId>
-				<version>1.0.3.Final</version>
+				<version>1.0.4</version>
 				<type>pom</type>
 				<scope>import</scope>
 			</dependency>
@@ -62,7 +62,7 @@
 		<dependency>
 			<groupId>org.wildfly.arquillian</groupId>
 			<artifactId>wildfly-arquillian-container-embedded</artifactId>
-			<version>2.0.0.Final</version>
+			<version>2.0.2.Final</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>
@@ -130,15 +130,9 @@
 			<scope>test</scope>
 		</dependency>
 		<dependency>
-			<groupId>org.jboss.arquillian.extension</groupId>
-			<artifactId>arquillian-persistence-dbunit</artifactId>
-			<version>1.0.0.Alpha7</version>
-			<scope>test</scope>
-		</dependency>
-		<dependency>
-			<groupId>org.dbunit</groupId>
-			<artifactId>dbunit</artifactId>
-			<version>2.5.1</version>
+			<groupId>org.arquillian.ape</groupId>
+			<artifactId>arquillian-ape-sql-container-dbunit</artifactId>
+			<version>2.0.0-alpha.4</version>
 			<scope>test</scope>
 		</dependency>
 	</dependencies>

--- a/lending-rest-server/src/test/scala/info/armado/ausleihe/remote/IssueGamesTest.scala
+++ b/lending-rest-server/src/test/scala/info/armado/ausleihe/remote/IssueGamesTest.scala
@@ -1,31 +1,17 @@
 package info.armado.ausleihe.remote
 
+import javax.inject.Inject
+
+import info.armado.ausleihe.remote.dataobjects.entities.{EnvelopeData, GameData, IdentityCardData}
+import info.armado.ausleihe.remote.dataobjects.inuse.{GameInUse, NotInUse}
+import info.armado.ausleihe.remote.requests.IssueGameRequest
+import info.armado.ausleihe.remote.results._
+import org.arquillian.ape.rdbms.UsingDataSet
 import org.jboss.arquillian.junit.Arquillian
-import org.jboss.arquillian.persistence.UsingDataSet
 import org.junit.Test
 import org.junit.runner.RunWith
-import org.scalatest.Matchers.convertToAnyShouldWrapper
-import org.scalatest.Matchers.equal
+import org.scalatest.Matchers.{convertToAnyShouldWrapper, equal}
 import org.scalatest.junit.JUnitSuite
-
-import info.armado.ausleihe.remote.dataobjects.entities.GameData
-import info.armado.ausleihe.remote.dataobjects.entities.IdentityCardData
-import info.armado.ausleihe.remote.requests.IssueGameRequest
-import info.armado.ausleihe.remote.results.IssueGamesSuccess
-import javax.enterprise.context.RequestScoped
-import javax.inject.Inject
-import javax.transaction.Transactional
-import javax.ws.rs.Consumes
-import javax.ws.rs.POST
-import javax.ws.rs.Path
-import javax.ws.rs.Produces
-import info.armado.ausleihe.remote.dataobjects.inuse.GameInUse
-import info.armado.ausleihe.remote.dataobjects.entities.EnvelopeData
-import info.armado.ausleihe.remote.results.LendingEntityInUse
-import info.armado.ausleihe.remote.results.IdentityCardHasIssuedGames
-import info.armado.ausleihe.remote.dataobjects.inuse.NotInUse
-import info.armado.ausleihe.remote.results.LendingEntityNotExists
-import info.armado.ausleihe.remote.results.IncorrectBarcode
 
 object IssueGamesTest extends WebDeployment
 

--- a/lending-rest-server/src/test/scala/info/armado/ausleihe/remote/IssueIdentityCardsTest.scala
+++ b/lending-rest-server/src/test/scala/info/armado/ausleihe/remote/IssueIdentityCardsTest.scala
@@ -1,23 +1,17 @@
 package info.armado.ausleihe.remote
 
-import org.junit.runner.RunWith
-import org.scalatest.junit.JUnitSuite
-import org.scalatest.Matchers.convertToAnyShouldWrapper
-import org.scalatest.Matchers.equal
-import org.jboss.arquillian.junit.Arquillian
 import javax.inject.Inject
+
+import info.armado.ausleihe.remote.dataobjects.entities.{EnvelopeData, GameData, IdentityCardData}
+import info.armado.ausleihe.remote.dataobjects.inuse.{EnvelopeInUse, IdentityCardInUse}
 import info.armado.ausleihe.remote.requests.IssueIdentityCardRequest
-import info.armado.ausleihe.remote.results.IssueIdentityCardSuccess
-import info.armado.ausleihe.remote.dataobjects.entities.IdentityCardData
-import org.jboss.arquillian.persistence.UsingDataSet
-import info.armado.ausleihe.remote.dataobjects.entities.EnvelopeData
+import info.armado.ausleihe.remote.results.{IncorrectBarcode, IssueIdentityCardSuccess, LendingEntityInUse, LendingEntityNotExists}
+import org.arquillian.ape.rdbms.UsingDataSet
+import org.jboss.arquillian.junit.Arquillian
 import org.junit.Test
-import info.armado.ausleihe.remote.results.LendingEntityInUse
-import info.armado.ausleihe.remote.dataobjects.inuse.IdentityCardInUse
-import info.armado.ausleihe.remote.dataobjects.entities.GameData
-import info.armado.ausleihe.remote.dataobjects.inuse.EnvelopeInUse
-import info.armado.ausleihe.remote.results.LendingEntityNotExists
-import info.armado.ausleihe.remote.results.IncorrectBarcode
+import org.junit.runner.RunWith
+import org.scalatest.Matchers.{convertToAnyShouldWrapper, equal}
+import org.scalatest.junit.JUnitSuite
 
 object IssueIdentityCardsTest extends WebDeployment
 

--- a/lending-rest-server/src/test/scala/info/armado/ausleihe/remote/ReturnGamesTest.scala
+++ b/lending-rest-server/src/test/scala/info/armado/ausleihe/remote/ReturnGamesTest.scala
@@ -1,20 +1,17 @@
 package info.armado.ausleihe.remote
 
-import org.junit.runner.RunWith
-import org.scalatest.junit.JUnitSuite
-import org.jboss.arquillian.junit.Arquillian
 import javax.inject.Inject
-import org.jboss.arquillian.persistence.UsingDataSet
-import org.junit.Test
-import org.scalatest.Matchers.convertToAnyShouldWrapper
-import org.scalatest.Matchers.equal
-import info.armado.ausleihe.remote.requests.ReturnGameRequest
+
 import info.armado.ausleihe.remote.dataobjects.entities.GameData
-import info.armado.ausleihe.remote.results.ReturnGameSuccess
-import info.armado.ausleihe.remote.results.LendingEntityInUse
 import info.armado.ausleihe.remote.dataobjects.inuse.NotInUse
-import info.armado.ausleihe.remote.results.LendingEntityNotExists
-import info.armado.ausleihe.remote.results.IncorrectBarcode
+import info.armado.ausleihe.remote.requests.ReturnGameRequest
+import info.armado.ausleihe.remote.results.{IncorrectBarcode, LendingEntityInUse, LendingEntityNotExists, ReturnGameSuccess}
+import org.arquillian.ape.rdbms.UsingDataSet
+import org.jboss.arquillian.junit.Arquillian
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.scalatest.Matchers.{convertToAnyShouldWrapper, equal}
+import org.scalatest.junit.JUnitSuite
 
 object ReturnGamesTest extends WebDeployment
 

--- a/lending-rest-server/src/test/scala/info/armado/ausleihe/remote/ReturnIdentityCardsTest.scala
+++ b/lending-rest-server/src/test/scala/info/armado/ausleihe/remote/ReturnIdentityCardsTest.scala
@@ -1,24 +1,17 @@
 package info.armado.ausleihe.remote
 
-import org.jboss.arquillian.junit.Arquillian
-import org.junit.runner.RunWith
-import org.scalatest.junit.JUnitSuite
-import org.scalatest.Matchers.convertToAnyShouldWrapper
-import org.scalatest.Matchers.equal
 import javax.inject.Inject
-import info.armado.ausleihe.remote.requests.ReturnIdentityCardRequest
-import info.armado.ausleihe.remote.dataobjects.entities.IdentityCardData
-import info.armado.ausleihe.remote.dataobjects.entities.EnvelopeData
-import info.armado.ausleihe.remote.results.ReturnIdentityCardSuccess
-import info.armado.ausleihe.remote.results.IdentityCardHasIssuedGames
-import info.armado.ausleihe.remote.dataobjects.entities.GameData
-import info.armado.ausleihe.remote.results.IdentityCardEnvelopeNotBound
-import info.armado.ausleihe.remote.results.LendingEntityInUse
+
+import info.armado.ausleihe.remote.dataobjects.entities.{EnvelopeData, GameData, IdentityCardData}
 import info.armado.ausleihe.remote.dataobjects.inuse.NotInUse
-import info.armado.ausleihe.remote.results.LendingEntityNotExists
-import info.armado.ausleihe.remote.results.IncorrectBarcode
-import org.jboss.arquillian.persistence.UsingDataSet
+import info.armado.ausleihe.remote.requests.ReturnIdentityCardRequest
+import info.armado.ausleihe.remote.results._
+import org.arquillian.ape.rdbms.UsingDataSet
+import org.jboss.arquillian.junit.Arquillian
 import org.junit.Test
+import org.junit.runner.RunWith
+import org.scalatest.Matchers.{convertToAnyShouldWrapper, equal}
+import org.scalatest.junit.JUnitSuite
 
 object ReturnIdentityCardsTest extends WebDeployment
 

--- a/lending-rest-server/src/test/scala/info/armado/ausleihe/remote/UniversalTest.scala
+++ b/lending-rest-server/src/test/scala/info/armado/ausleihe/remote/UniversalTest.scala
@@ -1,34 +1,17 @@
 package info.armado.ausleihe.remote
 
+import javax.inject.Inject
+
+import info.armado.ausleihe.remote.dataobjects.entities.{EnvelopeData, GameData, IdentityCardData}
+import info.armado.ausleihe.remote.dataobjects.inuse.{EnvelopeInUse, GameInUse, IdentityCardInUse, NotInUse}
+import info.armado.ausleihe.remote.requests.GameInformationRequest
+import info.armado.ausleihe.remote.results.{IncorrectBarcode, Information, LendingEntityInUse, LendingEntityNotExists}
+import org.arquillian.ape.rdbms.{ShouldMatchDataSet, UsingDataSet}
 import org.jboss.arquillian.junit.Arquillian
-import org.jboss.arquillian.persistence.UsingDataSet
 import org.junit.Test
 import org.junit.runner.RunWith
-import org.scalatest.Matchers.be
-import org.scalatest.Matchers.convertToAnyShouldWrapper
-import org.scalatest.Matchers.equal
+import org.scalatest.Matchers.{be, convertToAnyShouldWrapper, equal}
 import org.scalatest.junit.JUnitSuite
-
-import info.armado.ausleihe.remote.dataobjects.entities.EnvelopeData
-import info.armado.ausleihe.remote.dataobjects.entities.GameData
-import info.armado.ausleihe.remote.dataobjects.entities.IdentityCardData
-import info.armado.ausleihe.remote.dataobjects.inuse.EnvelopeInUse
-import info.armado.ausleihe.remote.dataobjects.inuse.GameInUse
-import info.armado.ausleihe.remote.dataobjects.inuse.IdentityCardInUse
-import info.armado.ausleihe.remote.dataobjects.inuse.NotInUse
-import info.armado.ausleihe.remote.requests.GameInformationRequest
-import info.armado.ausleihe.remote.results.IncorrectBarcode
-import info.armado.ausleihe.remote.results.Information
-import info.armado.ausleihe.remote.results.LendingEntityInUse
-import info.armado.ausleihe.remote.results.LendingEntityNotExists
-import javax.enterprise.context.RequestScoped
-import javax.inject.Inject
-import javax.transaction.Transactional
-import javax.ws.rs.Consumes
-import javax.ws.rs.GET
-import javax.ws.rs.POST
-import javax.ws.rs.Path
-import javax.ws.rs.Produces
 
 object UniversalTest extends WebDeployment
 
@@ -38,6 +21,7 @@ class UniversalTest extends JUnitSuite {
 
   @Test
   @UsingDataSet(Array("datasets/full.xml"))
+  @ShouldMatchDataSet(Array("datasets/full.xml"))
   def gamesBarcodeInUse(): Unit = {
     // test if an activated game can be correctly found
     universalService.barcodeInUse("11000014") should equal(LendingEntityInUse(GameData("11000014", "Titel 1", "Autor 1", "Verlag 1", "12", "2", "90 - 120"), GameInUse(IdentityCardData("33000010", "Marc Arndt"), EnvelopeData("44000013"))))
@@ -50,6 +34,7 @@ class UniversalTest extends JUnitSuite {
 
   @Test
   @UsingDataSet(Array("datasets/full.xml"))
+  @ShouldMatchDataSet(Array("datasets/full.xml"))
   def identityCardBarcodeInUse(): Unit = {
     universalService.barcodeInUse("33000010") should equal(LendingEntityInUse(IdentityCardData("33000010", "Marc Arndt"), IdentityCardInUse(EnvelopeData("44000013"),
       Array(GameData("11000014", "Titel 1", "Autor 1", "Verlag 1", "12", "2", "90 - 120"), GameData("11000025", "Titel 2", "Autor 1", "Verlag 2", "15", null, "90 - 120"), GameData("11000036", "Titel 2", "Autor 1", "Verlag 2", "15", null, "90 - 120")))))
@@ -60,6 +45,7 @@ class UniversalTest extends JUnitSuite {
 
   @Test
   @UsingDataSet(Array("datasets/full.xml"))
+  @ShouldMatchDataSet(Array("datasets/full.xml"))
   def envelopeBarcodeInUse(): Unit = {
     universalService.barcodeInUse("44000013") should equal(LendingEntityInUse(EnvelopeData("44000013"), EnvelopeInUse(IdentityCardData("33000010", "Marc Arndt"),
       Array(GameData("11000014", "Titel 1", "Autor 1", "Verlag 1", "12", "2", "90 - 120"), GameData("11000025", "Titel 2", "Autor 1", "Verlag 2", "15", null, "90 - 120"), GameData("11000036", "Titel 2", "Autor 1", "Verlag 2", "15", null, "90 - 120")))))
@@ -70,6 +56,7 @@ class UniversalTest extends JUnitSuite {
 
   @Test
   @UsingDataSet(Array("datasets/full.xml"))
+  @ShouldMatchDataSet(Array("datasets/full.xml"))
   def incorrectBarcodeInUse(): Unit = {
     universalService.barcodeInUse("11000013") should equal(IncorrectBarcode("11000013"))
     universalService.barcodeInUse("33000011") should equal(IncorrectBarcode("33000011"))
@@ -79,6 +66,7 @@ class UniversalTest extends JUnitSuite {
 
   @Test
   @UsingDataSet(Array("datasets/full.xml"))
+  @ShouldMatchDataSet(Array("datasets/full.xml"))
   def gamesStatusInformation(): Unit = {
     universalService.statusInformation("11000014") should equal(Information(Array(GameData("11000014", "Titel 1", "Autor 1", "Verlag 1", "12", "2", "90 - 120")), IdentityCardData("33000010", "Marc Arndt"), EnvelopeData("44000013")))
     universalService.statusInformation("11000025") should equal(Information(Array(GameData("11000025", "Titel 2", "Autor 1", "Verlag 2", "15", null, "90 - 120")), IdentityCardData("33000010", "Marc Arndt"), EnvelopeData("44000013")))
@@ -93,6 +81,7 @@ class UniversalTest extends JUnitSuite {
 
   @Test
   @UsingDataSet(Array("datasets/full.xml"))
+  @ShouldMatchDataSet(Array("datasets/full.xml"))
   def identityCardStatusInformation(): Unit = {
     universalService.statusInformation("33000010") should equal(Information(
         Array(GameData("11000014", "Titel 1", "Autor 1", "Verlag 1", "12", "2", "90 - 120"), GameData("11000025", "Titel 2", "Autor 1", "Verlag 2", "15", null, "90 - 120"), GameData("11000036", "Titel 2", "Autor 1", "Verlag 2", "15", null, "90 - 120")), 
@@ -105,6 +94,7 @@ class UniversalTest extends JUnitSuite {
 
   @Test
   @UsingDataSet(Array("datasets/full.xml"))
+  @ShouldMatchDataSet(Array("datasets/full.xml"))
   def envelopeStatusInformation(): Unit = {
     universalService.statusInformation("44000013") should equal(Information(
         Array(GameData("11000014", "Titel 1", "Autor 1", "Verlag 1", "12", "2", "90 - 120"), GameData("11000025", "Titel 2", "Autor 1", "Verlag 2", "15", null, "90 - 120"), GameData("11000036", "Titel 2", "Autor 1", "Verlag 2", "15", null, "90 - 120")), 
@@ -117,6 +107,7 @@ class UniversalTest extends JUnitSuite {
 
   @Test
   @UsingDataSet(Array("datasets/full.xml"))
+  @ShouldMatchDataSet(Array("datasets/full.xml"))
   def incorrectBarcodeStatusInformation(): Unit = {
     universalService.statusInformation("11000013") should equal(IncorrectBarcode("11000013"))
     universalService.statusInformation("33000011") should equal(IncorrectBarcode("33000011"))
@@ -126,6 +117,7 @@ class UniversalTest extends JUnitSuite {
 
   @Test
   @UsingDataSet(Array("datasets/full.xml"))
+  @ShouldMatchDataSet(Array("datasets/full.xml"))
   def gamesInformation(): Unit = {
     universalService.gamesInformation(GameInformationRequest("Titel", null, null, null, null, null, null)).foundGames.length should be(6)
     universalService.gamesInformation(GameInformationRequest("Titel 1", null, null, null, null, null, null)).foundGames.length should be(1)

--- a/lending-rest-server/src/test/scala/info/armado/ausleihe/remote/WebDeployment.scala
+++ b/lending-rest-server/src/test/scala/info/armado/ausleihe/remote/WebDeployment.scala
@@ -1,10 +1,10 @@
 package info.armado.ausleihe.remote
 
-import org.jboss.shrinkwrap.resolver.api.maven.Maven
+import org.jboss.arquillian.container.test.api.Deployment
 import org.jboss.shrinkwrap.api.ShrinkWrap
 import org.jboss.shrinkwrap.api.asset.EmptyAsset
 import org.jboss.shrinkwrap.api.spec.WebArchive
-import org.jboss.arquillian.container.test.api.Deployment
+import org.jboss.shrinkwrap.resolver.api.maven.Maven
 
 trait WebDeployment {
   @Deployment


### PR DESCRIPTION
This PR updates the arquillian persistence extension dependencies to the current version.
In addition this PR adds some `@ShouldMatchDataSet` annotations to the `UniversalTest` class.