### PR TITLE
Remove the unused dependencies from the old jsf admin webinterface

### DIFF
--- a/lending-ear/pom.xml
+++ b/lending-ear/pom.xml
@@ -26,6 +26,10 @@
 	</build>
 	<dependencies>
 		<dependency>
+			<groupId>org.scala-lang</groupId>
+			<artifactId>scala-library</artifactId>
+		</dependency>
+		<dependency>
 			<groupId>info.armado.darmstadtspielt</groupId>
 			<artifactId>lending-rest-interfaces</artifactId>
 			<version>0.0.1-SNAPSHOT</version>
@@ -41,26 +45,6 @@
 			<artifactId>lending-rest-server</artifactId>
 			<version>0.0.1-SNAPSHOT</version>
 			<type>war</type>
-		</dependency>
-		<dependency>
-			<groupId>org.scala-lang</groupId>
-			<artifactId>scala-library</artifactId>
-		</dependency>
-		<dependency>
-			<groupId>org.apache.poi</groupId>
-			<artifactId>poi-ooxml</artifactId>
-		</dependency>
-		<dependency>
-			<groupId>org.apache.poi</groupId>
-			<artifactId>poi-scratchpad</artifactId>
-		</dependency>
-		<dependency>
-			<groupId>org.primefaces</groupId>
-			<artifactId>primefaces</artifactId>
-		</dependency>
-		<dependency>
-			<groupId>au.com.flyingkite</groupId>
-			<artifactId>mobiledetect</artifactId>
 		</dependency>
 		<dependency>
 			<groupId>org.jboss.spec</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -25,16 +25,6 @@
 	<dependencyManagement>
 		<dependencies>
 			<dependency>
-				<groupId>org.primefaces</groupId>
-				<artifactId>primefaces</artifactId>
-				<version>6.0</version>
-			</dependency>
-			<dependency>
-				<groupId>org.primefaces.extensions</groupId>
-				<artifactId>primefaces-extensions</artifactId>
-				<version>6.0.0</version>
-			</dependency>
-			<dependency>
 				<groupId>ch.qos.logback</groupId>
 				<artifactId>logback-classic</artifactId>
 				<version>1.2.3</version>
@@ -43,21 +33,6 @@
 				<groupId>org.scala-lang</groupId>
 				<artifactId>scala-library</artifactId>
 				<version>2.12.2</version>
-			</dependency>
-			<dependency>
-				<groupId>org.apache.poi</groupId>
-				<artifactId>poi-ooxml</artifactId>
-				<version>3.15</version>
-			</dependency>
-			<dependency>
-				<groupId>org.apache.poi</groupId>
-				<artifactId>poi-scratchpad</artifactId>
-				<version>3.15</version>
-			</dependency>
-			<dependency>
-				<groupId>au.com.flyingkite</groupId>
-				<artifactId>mobiledetect</artifactId>
-				<version>1.1.1</version>
 			</dependency>
 			<dependency>
 				<groupId>org.jboss.spec</groupId>


### PR DESCRIPTION
This is done in preparation for #12 