### PR TITLE
Add rest endpoints for identity card specific operations to the admin server

### DIFF
--- a/lending-admin-server/src/main/scala/info/armado/ausleihe/model/AddGamesResponseDTO.scala
+++ b/lending-admin-server/src/main/scala/info/armado/ausleihe/model/AddGamesResponseDTO.scala
@@ -5,6 +5,18 @@ import javax.xml.bind.annotation.{XmlAccessType, XmlAccessorType, XmlRootElement
 object AddGamesResponseDTO {
   def apply(success: Boolean): AddGamesResponseDTO = new AddGamesResponseDTO(success)
 
+  /**
+    * Creates a new [[AddGamesResponseDTO]] instance based on the given `alreadyExistingBarcodes` and `alreadyExistingBarcodes`
+    * arrays.
+    * The created response will be marked as successful, iff both `alreadyExistingBarcodes` and `alreadyExistingBarcodes` are empty
+    *
+    * @param alreadyExistingBarcodes An array containing all barcodes belonging to already existing entities in the database
+    * @param emptyTitleBarcodes      An array containing all barcodes whose entries have no title set
+    * @return The created [[AddGamesResponseDTO]] instance
+    */
+  def apply(alreadyExistingBarcodes: Array[String], emptyTitleBarcodes: Array[String]): AddGamesResponseDTO =
+    new AddGamesResponseDTO(alreadyExistingBarcodes.isEmpty && emptyTitleBarcodes.isEmpty, alreadyExistingBarcodes, emptyTitleBarcodes)
+
   def apply(success: Boolean, alreadyExistingBarcodes: Array[String], emptyTitleBarcodes: Array[String]): AddGamesResponseDTO =
     new AddGamesResponseDTO(success, alreadyExistingBarcodes, emptyTitleBarcodes)
 }
@@ -15,5 +27,6 @@ class AddGamesResponseDTO(var success: Boolean,
                           var alreadyExistingBarcodes: Array[String],
                           var emptyTitleBarcodes: Array[String]) {
   def this() = this(false, Array(), Array())
+
   def this(success: Boolean) = this(success, Array(), Array())
 }

--- a/lending-admin-server/src/main/scala/info/armado/ausleihe/model/AddIdentityCardsResponseDTO.scala
+++ b/lending-admin-server/src/main/scala/info/armado/ausleihe/model/AddIdentityCardsResponseDTO.scala
@@ -1,0 +1,22 @@
+package info.armado.ausleihe.model
+
+import javax.xml.bind.annotation.{XmlAccessType, XmlAccessorType, XmlRootElement}
+
+object AddIdentityCardsResponseDTO {
+  def apply(success: Boolean): AddIdentityCardsResponseDTO = new AddIdentityCardsResponseDTO(success)
+
+  def apply(alreadyExistingBarcodes: Array[String]): AddIdentityCardsResponseDTO =
+    new AddIdentityCardsResponseDTO(alreadyExistingBarcodes.isEmpty, alreadyExistingBarcodes)
+
+  def apply(success: Boolean, alreadyExistingBarcodes: Array[String]): AddIdentityCardsResponseDTO =
+    new AddIdentityCardsResponseDTO(success, alreadyExistingBarcodes)
+}
+
+@XmlRootElement
+@XmlAccessorType(XmlAccessType.FIELD)
+class AddIdentityCardsResponseDTO(var success: Boolean,
+                                  var alreadyExistingBarcodes: Array[String]) {
+  def this() = this(false, Array())
+
+  def this(success: Boolean) = this(success, Array())
+}

--- a/lending-admin-server/src/main/scala/info/armado/ausleihe/model/IdentityCardDTO.scala
+++ b/lending-admin-server/src/main/scala/info/armado/ausleihe/model/IdentityCardDTO.scala
@@ -1,0 +1,10 @@
+package info.armado.ausleihe.model
+
+import javax.xml.bind.annotation.{XmlAccessType, XmlAccessorType, XmlRootElement}
+
+@XmlRootElement
+@XmlAccessorType(XmlAccessType.FIELD)
+class IdentityCardDTO(var barcode: String,
+                      var activated: Boolean) {
+  def this() = this(null, false)
+}

--- a/lending-admin-server/src/main/scala/info/armado/ausleihe/model/VerifyGamesResponseDTO.scala
+++ b/lending-admin-server/src/main/scala/info/armado/ausleihe/model/VerifyGamesResponseDTO.scala
@@ -3,6 +3,9 @@ package info.armado.ausleihe.model
 import javax.xml.bind.annotation.{XmlAccessType, XmlAccessorType, XmlRootElement}
 
 object VerifyGamesResponseDTO {
+  def apply(alreadyExistingBarcodes: Array[String], emptyTitleBarcodes: Array[String]): VerifyGamesResponseDTO =
+    new VerifyGamesResponseDTO(alreadyExistingBarcodes.isEmpty && emptyTitleBarcodes.isEmpty, alreadyExistingBarcodes, emptyTitleBarcodes)
+
   def unapply(vgr: VerifyGamesResponseDTO): Option[(Boolean, Array[String], Array[String])] =
     Some((vgr.valid, vgr.alreadyExistingBarcodes, vgr.emptyTitleBarcodes))
 }

--- a/lending-admin-server/src/main/scala/info/armado/ausleihe/model/VerifyIdentityCardsResponseDTO.scala
+++ b/lending-admin-server/src/main/scala/info/armado/ausleihe/model/VerifyIdentityCardsResponseDTO.scala
@@ -1,0 +1,18 @@
+package info.armado.ausleihe.model
+
+import javax.xml.bind.annotation.{XmlAccessType, XmlAccessorType, XmlRootElement}
+
+object VerifyIdentityCardsResponseDTO {
+  def apply(alreadyExistingBarcodes: Array[String]): VerifyIdentityCardsResponseDTO =
+    new VerifyIdentityCardsResponseDTO(alreadyExistingBarcodes.isEmpty, alreadyExistingBarcodes)
+
+  def unapply(vicr: VerifyIdentityCardsResponseDTO): Option[(Boolean, Array[String])] =
+    Some((vicr.valid, vicr.alreadyExistingBarcodes))
+}
+
+@XmlRootElement
+@XmlAccessorType(XmlAccessType.FIELD)
+class VerifyIdentityCardsResponseDTO(var valid: Boolean,
+                                     var alreadyExistingBarcodes: Array[String]) {
+  def this() = this(false, Array())
+}

--- a/lending-admin-server/src/main/scala/info/armado/ausleihe/remote/IdentityCardService.scala
+++ b/lending-admin-server/src/main/scala/info/armado/ausleihe/remote/IdentityCardService.scala
@@ -1,0 +1,126 @@
+package info.armado.ausleihe.remote
+
+import javax.enterprise.context.RequestScoped
+import javax.inject.Inject
+import javax.transaction.Transactional
+import javax.ws.rs._
+import javax.ws.rs.core.{MediaType, Response}
+
+import info.armado.ausleihe.database.access.IdentityCardDao
+import info.armado.ausleihe.database.barcode.{Barcode, ValidBarcode, ValidateBarcode}
+import info.armado.ausleihe.database.dataobjects.Prefix
+import info.armado.ausleihe.database.entities.IdentityCard
+import info.armado.ausleihe.model.{VerifyIdentityCardsResponseDTO, _}
+
+@Path("/identitycards")
+@RequestScoped
+class IdentityCardService {
+  @Inject
+  var identityCardDao: IdentityCardDao = _
+
+  /**
+    * Adds a list of identity cards to the database.
+    * Before the identity cards are added, the input data is first verified and validated.
+    * If at least one input entry is invalid, because for example its barcode is already contained in the database,
+    * the whole method terminates and no identity card is added to the database.
+    * In both the successful and the unsuccessful cases, an [[AddIdentityCardsResponseDTO]] object is returned
+    *
+    * @param identityCardDtos The identity cards to be added
+    * @return A response object, containing the result of the operation
+    */
+  @PUT
+  @Produces(Array(MediaType.APPLICATION_JSON))
+  @Consumes(Array(MediaType.APPLICATION_JSON))
+  @Path("/add")
+  @Transactional
+  def addIdentityCards(identityCardDtos: Array[IdentityCardDTO]): Response = verify(identityCardDtos) match {
+    case VerifyIdentityCardsResponseDTO(true, Array()) => {
+      // convert IdentityCardDTO objects to IdentityCard objects
+      val identityCards = identityCardDtos.map(identityCardDto => toIdentityCard(identityCardDto))
+
+      // insert the IdentityCard objects into the database
+      identityCardDao.insert(identityCards)
+
+      // send success result to the client
+      Response.ok(AddIdentityCardsResponseDTO(true)).build()
+    }
+    case VerifyIdentityCardsResponseDTO(false, alreadyExistingBarcodes) => {
+      // the given identity card information are not valid
+      Response.ok(AddIdentityCardsResponseDTO(alreadyExistingBarcodes)).build()
+    }
+    case _ => Response.status(Response.Status.PRECONDITION_FAILED).build()
+  }
+
+  /**
+    * Selects all identity cards from the database
+    *
+    * @return An array containing all identity cards inside the database
+    */
+  @GET
+  @Produces(Array(MediaType.APPLICATION_JSON))
+  @Path("/all")
+  @Transactional
+  def selectAllIdentityCards(): Response = Response.ok(
+    identityCardDao.selectAll().map(identityCard => toIdentityCardDTO(identityCard)).toArray).build()
+
+  /**
+    * Selects all identity cards from the database, that have a barcode, which is contained in the given `barcodes` array.
+    * If no identity cards can be found for a given barcode, the barcode is ignored
+    *
+    * @param barcodes An array containing the barcodes of all queried identity cards
+    * @return An array containing the found identity cards belonging to the given barcodes
+    */
+  @POST
+  @Consumes(Array(MediaType.APPLICATION_JSON))
+  @Produces(Array(MediaType.APPLICATION_JSON))
+  @Path("/select")
+  @Transactional
+  def selectIdentityCards(barcodes: Array[String]): Response = Response.ok(
+    barcodes.flatMap(barcode => ValidateBarcode(barcode) match {
+      case ValidBarcode(barcode@Barcode(Prefix.IdentityCards, _, _)) => identityCardDao.selectByBarcode(barcode)
+      case _ => None
+    }).map(identityCard => toIdentityCardDTO(identityCard))
+  ).build()
+
+  /**
+    * Verifies a given list of identity cards, if they:
+    * - don't already exist in the database
+    *
+    * @param identityCards The identity card information to be checked
+    * @return A response wrapping a [[VerifyIdentityCardsResponseDTO]] object
+    */
+  @PUT
+  @Produces(Array(MediaType.APPLICATION_JSON))
+  @Consumes(Array(MediaType.APPLICATION_JSON))
+  @Path("/verify")
+  @Transactional
+  def verifyIdentityCards(identityCards: Array[IdentityCardDTO]): Response = Response.ok(verify(identityCards)).build()
+
+  private def verify(identityCards: Array[IdentityCardDTO]): VerifyIdentityCardsResponseDTO = {
+    // find entries with wrong or already existing barcodes
+    val alreadyExistingIdentityCardBarcodes = identityCards.filter(identityCards => ValidateBarcode(identityCards.barcode) match {
+      case ValidBarcode(barcode@Barcode(Prefix.IdentityCards, _, _)) => identityCardDao.exists(barcode)
+      case _ => true
+    }).map(_.barcode)
+
+    VerifyIdentityCardsResponseDTO(alreadyExistingIdentityCardBarcodes)
+  }
+
+  private def toIdentityCardDTO(identityCard: IdentityCard): IdentityCardDTO = {
+    val result = new IdentityCardDTO()
+
+    result.barcode = identityCard.barcode.toString
+
+    result.activated = identityCard.available
+
+    result
+  }
+
+  private def toIdentityCard(identityCardDto: IdentityCardDTO): IdentityCard = {
+    val result = IdentityCard(Barcode(identityCardDto.barcode))
+
+    Option(identityCardDto.activated).foreach(activated => result.available = activated)
+
+    result
+  }
+}

--- a/lending-database/src/main/scala/info/armado/ausleihe/database/entities/IdentityCard.scala
+++ b/lending-database/src/main/scala/info/armado/ausleihe/database/entities/IdentityCard.scala
@@ -6,6 +6,19 @@ import info.armado.ausleihe.database.barcode.Barcode
 import info.armado.ausleihe.database.util.JPAAnnotations._
 
 /**
+  * Factory for [[IdentityCard]] instances.
+  */
+object IdentityCard {
+  /**
+    * Creates a IdentityCard instance with a given barcode
+    *
+    * @param barcode The barcode of the identity card
+    * @return The new IdentityCard instance
+    */
+  def apply(barcode: Barcode): IdentityCard = new IdentityCard(barcode, false)
+}
+
+/**
   * An identity card, which can be bound to an [[Envelope]]
   *
   * @author Marc Arndt


### PR DESCRIPTION
This PR does the following:

- make some small changes to the games rest endpoint at the lending-admin-server
- add a new rest endpoint for identity specific stuff at the lending-admin-server
- add some support rest dto classes at the lending-admin-server