### PR TITLE
Remove Java 10 from Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,8 +9,6 @@ jobs:
     jdk: oraclejdk8
   - name: Linux Oracle JDK 9
     jdk: oraclejdk9
-  - name: Linux Oracle JDK 10
-    jdk: oraclejdk10
   - name: Linux Oracle JDK 11
     jdk: oraclejdk11
   - name: Linux OpenJDK 11


### PR DESCRIPTION
This PR removes Oracle JDK 10 from travis, because it is not supported anymore by Oracle.