### PR TITLE
Add the owner name to the lend game search table output

### DIFF
--- a/lending-client-application/src/main/scala/info/armado/ausleihe/client/graphics/components/skin/GameSearchTableViewSkin.scala
+++ b/lending-client-application/src/main/scala/info/armado/ausleihe/client/graphics/components/skin/GameSearchTableViewSkin.scala
@@ -71,9 +71,19 @@ class GameSearchTableViewSkin(gameSearchTableView: GameSearchTableView) extends 
     sortType = SortType.Descending
   }
 
+  val ownerColumn: TableColumn[LendGameStatusDTO, String] = new TableColumn[LendGameStatusDTO, String] {
+    text = "An"
+    cellValueFactory = {
+      value => new StringProperty(value.value.owner)
+    }
+    prefWidth = 200
+    editable = false
+    sortType = SortType.Ascending
+  }
+
   val tableView: TableView[LendGameStatusDTO] = new TableView[LendGameStatusDTO]() {
-    columns ++= List(barcodeColumn, titleColumn, authorColumn, publisherColumn, minimumAgeColumn, playerCountColumn, gameDurationColumn, lendColumn)
-    sortOrder ++= List(lendColumn, titleColumn)
+    columns ++= List(barcodeColumn, titleColumn, authorColumn, publisherColumn, minimumAgeColumn, playerCountColumn, gameDurationColumn, lendColumn, ownerColumn)
+    sortOrder ++= List(lendColumn, ownerColumn, titleColumn)
     rowFactory = table => new TableRow[LendGameStatusDTO] {
       item.onChange((observable, oldLendGameStatus, newLendGameStatus) =>
         if (Option(newLendGameStatus).exists(_.lend)) {

--- a/lending-client-backend/src/main/scala/info/armado/ausleihe/client/util/DTOExtensions.scala
+++ b/lending-client-backend/src/main/scala/info/armado/ausleihe/client/util/DTOExtensions.scala
@@ -2,9 +2,9 @@ package info.armado.ausleihe.client.util
 
 import java.time.{Duration, LocalDateTime}
 
-import info.armado.ausleihe.database.entities._
 import info.armado.ausleihe.client.transport.dataobjects.LendGameStatusDTO
 import info.armado.ausleihe.client.transport.dataobjects.entities.{EnvelopeDTO, GameDTO, IdentityCardDTO}
+import info.armado.ausleihe.database.entities._
 
 object DTOExtensions {
 
@@ -49,8 +49,10 @@ object DTOExtensions {
 
   implicit class LendGameStatusDataExtension(game: Game) {
     def toLendGameStatusDTO(lendGame: Option[LendGame]): LendGameStatusDTO = lendGame match {
-      case None => LendGameStatusDTO(game.toGameDTO, false, null)
-      case Some(LendGame(_, _, lendTime, _)) => LendGameStatusDTO(game.toGameDTO, true, Duration.between(lendTime, LocalDateTime.now))
+      case None =>
+        LendGameStatusDTO(game.toGameDTO)
+      case Some(LendGame(_, lendIdentityCard, lendTime, _)) =>
+        LendGameStatusDTO(game.toGameDTO, Duration.between(lendTime, LocalDateTime.now), lendIdentityCard.owner)
     }
   }
 

--- a/lending-client-interfaces/src/main/scala/info/armado/ausleihe/client/transport/dataobjects/LendGameStatusDTO.scala
+++ b/lending-client-interfaces/src/main/scala/info/armado/ausleihe/client/transport/dataobjects/LendGameStatusDTO.scala
@@ -7,11 +7,34 @@ import info.armado.ausleihe.client.transport.dataobjects.entities._
 import info.armado.ausleihe.client.transport.util.Annotations._
 import javax.xml.bind.annotation.{XmlAccessType, XmlAccessorType, XmlRootElement}
 
+object LendGameStatusDTO {
+  /**
+    * Create a [[LendGameStatusDTO]] instance for an unlend [[GameDTO]] object
+    *
+    * @param game The unlend game
+    * @return The created [[LendGameStatusDTO]] instance
+    */
+  def apply(game: GameDTO): LendGameStatusDTO =
+    LendGameStatusDTO(game, false, null, null)
+
+  /**
+    * Create a [[LendGameStatusDTO]] instance for a lend [[GameDTO]] object
+    *
+    * @param game         The unlend game
+    * @param lendDuration The current lend duration (time between lend start time until now)
+    * @param owner        The owner of the identity card if set
+    * @return The created [[LendGameStatusDTO]] instance
+    */
+  def apply(game: GameDTO, lendDuration: Duration, owner: String): LendGameStatusDTO =
+    LendGameStatusDTO(game, true, lendDuration, owner)
+}
+
 @XmlRootElement
 @XmlAccessorType(XmlAccessType.FIELD)
 case class LendGameStatusDTO(var game: GameDTO,
                              var lend: Boolean,
-                             @XmlJavaTypeAdapter(value = classOf[DurationAdapter]) var lendDuration: Duration) {
+                             @XmlJavaTypeAdapter(value = classOf[DurationAdapter]) var lendDuration: Duration,
+                             var owner: String) {
 
-  def this() = this(null, false, null)
+  def this() = this(null, false, null, null)
 }


### PR DESCRIPTION
In addition this PR does the following:
- add the owner to the `LendGameStatusDTO` transport class
- send the owner from during the game search rest call to the lending client application